### PR TITLE
[F0-MODEL] Corregir enfoque hacia prueba de mercado y viabilidad unipersonal

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,42 @@ API-Dian está en fase de **modelo experimental**.
 
 El objetivo inmediato no es construir todavía toda la plataforma fiscal completa, sino validar el modelo de trabajo, la arquitectura inicial, los agentes, el manejo de errores, los paquetes, la operación mínima y la forma en que el mercado recibe la propuesta.
 
+## Enfoque actual corregido
+
+API-Dian está en **F0: consolidación del modelo experimental**.
+
+El objetivo inmediato **no** es construir la API DIAN completa.
+
+El objetivo inmediato es:
+
+1. Consolidar la documentación del modelo.
+2. Definir hipótesis de mercado.
+3. Diseñar una prueba de fogueo usando canales como Meta Ads, Facebook Ads, landing page, WhatsApp y entrevistas.
+4. Construir solo lo mínimo necesario para probar recepción real.
+5. Diagnosticar si el modelo puede ser rentable y mantenible por una sola persona.
+6. Decidir qué servicios DIAN conviene construir primero.
+
+La construcción inicial no es el producto final.
+La construcción inicial es una herramienta para aprender del mercado.
+
+### Pregunta central del proyecto
+
+```text
+¿Puede una sola persona construir, vender, operar y mantener una API DIAN rentable,
+con servicios limitados, en el mercado actual?
+```
+
+Pregunta secundaria:
+
+```text
+¿Qué habría que cambiar en el modelo para que eso sí sea posible?
+```
+
 Documentos clave de esta fase:
 
 - [`docs/modelo-experimental.md`](./docs/modelo-experimental.md) — define qué significa “modelo” en este proyecto y cómo se trabaja.
 - [`docs/prueba-fogueo-mercado.md`](./docs/prueba-fogueo-mercado.md) — define cómo probar la recepción del mercado antes de escalar construcción.
+- [`docs/f0-correccion-enfoque-mercado.md`](./docs/f0-correccion-enfoque-mercado.md) — registra la corrección estratégica: primero mercado y viabilidad, luego MVP real.
 
 ---
 
@@ -22,11 +54,17 @@ sobre una plataforma multi-tenant.
 
 ## Estado actual
 
-- **F0** — Workflow, foundations y consolidación del modelo experimental.
-- **F0.5** — Prueba de fogueo del mercado: recepción, objeciones, precio, soporte, contador y mensajes comerciales.
-- **F1** — Arquitectura inicial: app **NestJS + Fastify** en `apps/api/` según [ADR-001](./ADR/ADR-001-stack-tecnologico.md) y [ADR-002](./ADR/ADR-002-estructura-modulos.md). No apto para producción.
+- **F0** — Consolidación documental del modelo experimental.
+- **F0.5** — Diseño de prueba de fogueo de mercado.
+- **F1** — Prototipo mínimo solo para probar recepción real, no producto final.
+- **F2** — Ejecución de prueba con Meta Ads / Facebook Ads / landing / WhatsApp.
+- **F3** — Diagnóstico de viabilidad para una sola persona.
+- **F4** — Decisión del MVP real.
+- **F5** — Construcción técnica del MVP validado.
 
 ## Flujo de alto nivel
+
+> El flujo técnico siguiente representa la visión larga. No es el siguiente paso de F0. Antes se debe validar mercado y viabilidad unipersonal.
 
 ```
 Integrador ──JSON──▶ [API-DIAN] ──XML UBL──▶ DIAN

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,172 +1,151 @@
 # Roadmap API-DIAN
 
-Fases de construcción del proyecto API-DIAN.
-Objetivo final: plataforma multi-tenant que cubra todos los servicios
-fiscales DIAN (factura electrónica, notas crédito/débito, documento
-soporte, nómina, etc.) sobre una arquitectura modular y escalable.
+Fases corregidas del proyecto API-DIAN.
+
+El objetivo de esta versión del roadmap no es empujar construcción DIAN prematura.
+El objetivo es ordenar el aprendizaje: primero modelo, mercado y viabilidad; después MVP real.
+
+## Pregunta central
+
+```text
+¿Puede una sola persona construir, vender, operar y mantener una API DIAN rentable,
+con servicios limitados, en el mercado actual?
+```
+
+Pregunta secundaria:
+
+```text
+¿Qué habría que cambiar en el modelo para que eso sí sea posible?
+```
 
 ---
 
-## F0 — Workflow, foundations y método de trabajo
+## Orden estratégico corregido
+
+```text
+F0  — Consolidación documental del modelo
+F0.5 — Diseño de prueba de fogueo de mercado
+F1  — Prototipo mínimo para prueba de mercado
+F2  — Ejecución de prueba con Meta Ads / Facebook Ads / landing / WhatsApp
+F3  — Diagnóstico de viabilidad para una sola persona
+F4  — Decisión del MVP real
+F5  — Construcción técnica del MVP validado
+```
+
+La construcción inicial no es el producto final.
+La construcción inicial es una herramienta para aprender del mercado.
+
+---
+
+## F0 — Consolidación documental del modelo
+
 **Estado: 🚧 En progreso**
 
-Fase previa a cualquier construcción funcional.
-Define cómo se trabaja, no el dominio fiscal.
+Fase previa a cualquier construcción funcional DIAN.
 
-Entregables:
-- `docs/workflow.md` — flujo de trabajo en 8 pasos.
-- `docs/estimation-and-definition-of-done.md` — tallas, DoD y calibración.
-- `docs/templates/` — plantillas de sesión, módulo y checklist.
-- `docs/context-policy.md` — política de contexto mínimo para IA.
-- `docs/supabase-workflow.md` — flujo de validación con Supabase CLI.
+Objetivo:
 
-Paquetes de trabajo (issues):
+- Consolidar la idea.
+- Separar visión larga de alcance inmediato.
+- Definir hipótesis de mercado.
+- Definir servicios DIAN potencialmente manejables por una sola persona.
+- Descartar servicios demasiado riesgosos para el inicio.
+- Documentar riesgos, costos, paquetes hipotéticos y criterios de viabilidad.
 
-| Código | Título | Talla | Estado |
-|--------|--------|-------|--------|
-| F0-WKF-01 | Definir workflow y herramientas IA | S | ⏳ Pendiente |
-| F0-WKF-02 | Crear plantillas sesión/módulo/checklist | S | ⏳ Pendiente |
-| F0-WKF-03 | Política de contexto mínimo y docs persistentes | S | ⏳ Pendiente |
-| F0-WKF-04 | Flujo de validación CLI + Supabase | M | ⏳ Pendiente |
-| F0-WKF-05 | Criterios de cierre por módulo | S | ⏳ Pendiente |
+Issues relacionados:
+
+- #44 — Entorno diario.
+- #42 — Modelo experimental y viabilidad para una sola persona.
 
 ---
 
-## F1 — Arquitectura y decisiones iniciales
+## F0.5 — Diseño de prueba de fogueo de mercado
+
 **Estado: ⏸ No iniciado**
 
-Define la arquitectura base de la plataforma que soportará
-todos los servicios fiscales DIAN.
+Objetivo:
 
-Temas principales:
-- Estructura de capas y módulos del sistema.
-- Decisiones de stack tecnológico (ADRs).
-- Organización de servicios internos.
-- Primeros endpoints de salud y verificación.
-- Modelo conceptual de documentos fiscales y flujos.
+Diseñar una prueba de mercado antes de construir el producto completo.
+
+Canales previstos:
+
+- Meta Ads.
+- Facebook Ads.
+- Landing page.
+- WhatsApp.
+- Publicaciones orgánicas.
+- Contacto con contadores.
+- Contacto con negocios pequeños.
+- Contacto con integradores/POS.
+
+Issue relacionado:
+
+- #43 — Prueba de fogueo del mercado.
 
 ---
 
-## F2 — Núcleo de plataforma (app base, colas, health)
+## F1 — Prototipo mínimo para prueba de mercado
+
 **Estado: ⏸ No iniciado**
 
-Temas principales:
-- App base ejecutándose con estructura de módulos definida.
-- Health checks para integradores y monitoreo interno.
-- Infraestructura de colas para procesamiento de documentos.
-- Logging básico y trazabilidad inicial.
-- Estándares de configuración por entorno (dev, staging, prod).
+Objetivo:
+
+Construir solo lo mínimo necesario para probar recepción real.
+
+No es el MVP final.
+No debe incluir todavía XML DIAN, firma digital, envío DIAN, CUFE/CUDE, validaciones UBL, PDF ni lógica fiscal de producción.
 
 ---
 
-## F3 — Tenant, identidad y maestros
+## F2 — Ejecución de prueba con Meta Ads / Facebook Ads / landing / WhatsApp
+
 **Estado: ⏸ No iniciado**
 
-Temas principales:
-- Modelo de tenant/empresa (multi-tenant desde el día 1).
-- Usuarios, roles y permisos asociados al tenant.
-- RLS (Row Level Security) por tenant en Supabase.
-- Maestros de configuración fiscal:
-  resoluciones, numeraciones, datos del emisor.
+Objetivo:
+
+Medir recepción real, costo por lead, objeciones, precio aceptado, confianza, tipo de cliente y soporte requerido.
 
 ---
 
-## F4 — Documento fiscal, emisión DIAN y primer canal
+## F3 — Diagnóstico de viabilidad para una sola persona
+
 **Estado: ⏸ No iniciado**
 
-Temas principales:
-- Modelo de documentos fiscales y estados internos:
-  recibido → encolado → enviado → aceptado/rechazado → notificado.
-- Motor de generación XML/UBL.
-- Adaptador para primer canal DIAN (sandbox).
-- Manejo de respuesta DIAN y persistencia de estados.
-- Primer flujo completo: integrador → DIAN → adquiriente.
+Objetivo:
+
+Responder con evidencia si el modelo puede ser rentable y mantenible por una sola persona.
+
+Resultados posibles:
+
+- Viable.
+- No viable.
+- Viable solo si cambia el paquete.
+- Viable solo con otro cliente objetivo.
+- Viable solo con automatización.
+- No viable para una sola persona.
 
 ---
 
-## F5 — Retorno al ERP (consultas y webhooks)
+## F4 — Decisión del MVP real
+
 **Estado: ⏸ No iniciado**
 
-Temas principales:
-- Endpoints de consulta de documentos para integradores/ERPs.
-- Webhooks de salida con estados relevantes.
-- Reintentos y manejo de fallos de notificación.
-- Sincronización de estados entre API-DIAN y ERP.
+Objetivo:
+
+Decidir qué servicios DIAN conviene construir primero según evidencia de mercado y riesgo operativo.
 
 ---
 
-## F5.5 — Integraciones comerciales y e-commerce
+## F5 — Construcción técnica del MVP validado
+
 **Estado: ⏸ No iniciado**
 
-Fase puente entre F5 y F6: define cómo el producto encaja en los flujos donde viven pedidos y ventas (e-commerce, marketplaces, ERPs/POS) en Colombia.
+Objetivo:
 
-Temas principales:
-- Priorización de canales conectables (Shopify, Mercado Libre, WooCommerce, Odoo/ERP, etc.).
-- Definición del modelo de adaptadores (nativo vs partners vs capa genérica).
-- Contrato interno `commerce-order -> fiscal-document`.
-- Normalización de eventos (entrada/salida) y webhooks.
-- Criterios de prioridad comercial por canal (scoring) y backlog inicial.
+Construir técnicamente solo lo que la prueba y el diagnóstico hayan justificado.
 
-Milestone GitHub: **F5.5 — Integraciones comerciales y e-commerce**.
+Regla:
 
----
-
-## F6 — Operación, confiabilidad y gobierno DIAN
-**Estado: ⏸ No iniciado**
-
-Temas principales:
-- Observabilidad: logs estructurados, métricas, dashboards básicos.
-- Auditoría y trazabilidad de operaciones fiscales.
-- Panel mínimo de soporte interno.
-- DLQ (Dead Letter Queue), replay manual de documentos fallidos.
-- Gestión de cambios normativos DIAN (versionado de esquemas).
-
----
-
-## F7 — Cobertura fiscal ampliada y multi-canal
-**Estado: ⏸ No iniciado**
-
-Temas principales:
-- Notas crédito y débito electrónicas.
-- Documento soporte de adquisiciones.
-- Nómina electrónica.
-- Soporte para múltiples canales de emisión DIAN.
-- Compatibilidad con cambios normativos.
-
----
-
-## F8 — SaaS comercial y escala
-**Estado: ⏸ No iniciado**
-
-Temas principales:
-- Planes y límites por tenant.
-- Contadores de uso y métricas de negocio.
-- Hardening de seguridad para producción.
-- Performance y escalabilidad horizontal.
-- Documentación pública para integradores.
-
----
-
-## Módulos del dominio
-
-| Módulo | Descripción | Fases principales |
-|--------|-------------|-------------------|
-| plataforma-tenants | Multi-tenant, usuarios, permisos | F1–F3 |
-| integrador-api | Contrato JSON de entrada, autenticación | F1–F2 |
-| documentos-fiscales | Modelo y ciclo de documentos | F4 |
-| emision-dian | Generación XML/UBL, envío, respuesta | F4 |
-| procesamiento-interno | Colas, workers, DLQ, replay | F2, F6 |
-| notificacion-adquiriente | Email con XML/PDF | F4 |
-| observabilidad-gobierno | Logs, métricas, auditoría | F6 |
-| cumplimiento-dian | Normativa, versiones, pruebas | F4–F7 |
-
----
-
-## Convenciones
-
-- Cada issue se asocia a un milestone F0–F8.
-- Títulos de issue: `[F<n>-<CÓDIGO>] Descripción`
-- Labels: `role-*`, `type-*`, `size-*`, `priority-*`, `module-*`
-- Ramas: `feature/<rol>/<issue-n>-slug` desde `dev`
-- Detalle de workflow en `docs/workflow.md`
-- Detalle de estimación y DoD en `docs/estimation-and-definition-of-done.md`
+```text
+No se construye el MVP real hasta tener evidencia mínima del mercado.
+```

--- a/docs/daily-checklist.md
+++ b/docs/daily-checklist.md
@@ -2,6 +2,13 @@
 
 Marca mentalmente o en el Project lo que aplique.
 
+## Antes de construir algo técnico
+
+- [ ] Confirmar si la tarea pertenece a documentación, hipótesis, prueba de mercado o diagnóstico.
+- [ ] Confirmar que no se está saltando directo a XML, firma, envío DIAN o lógica fiscal real.
+- [ ] Confirmar qué aprendizaje de mercado busca producir la tarea.
+- [ ] Si se construye algo, debe ser mínimo y orientado a probar recepción real, no el producto final.
+
 ## Antes de codificar
 
 - [ ] Una tarjeta en progreso (WIP = 1), alineada al roadmap

--- a/docs/f0-correccion-enfoque-evidencia.md
+++ b/docs/f0-correccion-enfoque-evidencia.md
@@ -1,0 +1,63 @@
+# Evidencia — Corrección de enfoque F0
+
+## Fecha
+
+2026-06-28
+
+## Rama
+
+feature/docs/f0-correccion-enfoque-mercado
+
+## Motivo
+
+Se corrigió el enfoque del proyecto para evitar pasar prematuramente de entorno listo a construcción técnica DIAN.
+
+## Corrección aplicada
+
+Antes:
+
+```text
+entorno listo → construir API DIAN
+```
+
+Ahora:
+
+```text
+documentación → modelo → hipótesis → prueba de mercado → diagnóstico → decisión de MVP
+```
+
+## Archivos actualizados
+
+- `README.md`
+- `ROADMAP.md`
+- `docs/modelo-experimental.md`
+- `docs/prueba-fogueo-mercado.md`
+- `docs/workflow.md`
+- `docs/session-context.md`
+- `docs/daily-checklist.md`
+
+## Archivos creados
+
+- `docs/f0-correccion-enfoque-mercado.md`
+- `docs/f0-correccion-enfoque-evidencia.md`
+
+## Issues actualizados o comentados
+
+- #44 — comentario de actualización de enfoque: https://github.com/Abraha33/API-Dian/issues/44#issuecomment-4827393586
+- #42 — comentario de objetivo del modelo experimental: https://github.com/Abraha33/API-Dian/issues/42#issuecomment-4827393473
+- #43 — comentario de diseño de prueba de fogueo: https://github.com/Abraha33/API-Dian/issues/43#issuecomment-4827393637
+- #45 — comentario sobre prueba del modelo, no API completa: https://github.com/Abraha33/API-Dian/issues/45#issuecomment-4827393530
+
+## Obsidian actualizado o parche creado
+
+- Obsidian actualizado directamente en `Proyectos/NeoDIAN-Control/`.
+
+## Estado final
+
+- [x] README actualizado.
+- [x] Roadmap actualizado.
+- [x] Documento de corrección creado.
+- [x] Issues #42, #43, #44 y #45 revisados.
+- [x] Obsidian actualizado o parche preparado.
+- [x] No se implementó lógica DIAN.
+- [x] No se construyeron módulos fiscales.

--- a/docs/f0-correccion-enfoque-mercado.md
+++ b/docs/f0-correccion-enfoque-mercado.md
@@ -1,0 +1,71 @@
+# Corrección de enfoque — Modelo, mercado y construcción
+
+## Fecha
+
+2026-06-28
+
+## Corrección principal
+
+El proyecto no debe pasar de entorno listo a construcción técnica de módulos DIAN.
+
+Antes de construir, se debe consolidar el modelo y diseñar una prueba de fogueo de mercado.
+
+## Enfoque corregido
+
+```text
+documentación completa
+↓
+modelo consolidado
+↓
+hipótesis de mercado
+↓
+prueba de fogueo
+↓
+prototipo mínimo solo si ayuda a probar
+↓
+diagnóstico de viabilidad
+↓
+decisión de MVP real
+```
+
+## Pregunta central
+
+¿Puede una sola persona construir, vender, operar y mantener una API DIAN rentable, con servicios limitados, en el mercado actual?
+
+## Pregunta secundaria
+
+¿Qué habría que cambiar para que esa meta sea posible?
+
+## Implicación
+
+La construcción inicial no es el producto final.
+
+La construcción inicial sirve para probar recepción real, resolver dudas prácticas y medir si el mercado responde.
+
+## Canales previstos para prueba
+
+- Meta Ads.
+- Facebook Ads.
+- Landing page.
+- WhatsApp.
+- Publicaciones orgánicas.
+- Contacto con contadores.
+- Contacto con negocios pequeños.
+- Contacto con integradores.
+
+## Qué debe producir la prueba
+
+Un diagnóstico sobre:
+
+- Viabilidad comercial.
+- Cliente ideal.
+- Precio aceptable.
+- Servicios DIAN iniciales.
+- Riesgo operativo.
+- Soporte necesario.
+- Capacidad real de una sola persona.
+- Cambios necesarios al modelo.
+
+## Regla de decisión
+
+No se construye el MVP real hasta tener evidencia mínima del mercado.

--- a/docs/modelo-experimental.md
+++ b/docs/modelo-experimental.md
@@ -8,6 +8,32 @@ El objetivo inmediato no es construir todavía toda la plataforma fiscal complet
 
 Este repositorio funciona como laboratorio controlado para convertir ideas en documentación, tickets, pruebas, código y evidencia.
 
+La construcción inicial no es el producto final. La construcción inicial es una herramienta para probar recepción real del mercado y diagnosticar viabilidad.
+
+---
+
+## Pregunta central del modelo
+
+```text
+¿Puede una sola persona construir, vender, operar y mantener una API DIAN rentable,
+con servicios limitados, en el mercado actual?
+```
+
+Pregunta secundaria:
+
+```text
+¿Qué habría que cambiar en el modelo para que eso sí sea posible?
+```
+
+El modelo debe responder:
+
+- ¿Es viable construir y mantener esto con una sola persona?
+- ¿Qué servicios DIAN sí son manejables por una sola persona?
+- ¿Qué servicios deben descartarse al inicio?
+- ¿Qué partes requieren automatización?
+- ¿Qué partes exigirían contratar personal?
+- ¿Qué precio/paquete parece viable?
+
 ---
 
 ## Qué significa “modelo” en este proyecto
@@ -51,6 +77,9 @@ El modelo busca probar:
 - Cómo se manejan errores DIAN.
 - Cómo se empaquetan servicios para una operación de una sola persona.
 - Cómo reacciona el mercado ante la propuesta.
+- Qué servicios DIAN puede mantener una sola persona sin saturarse.
+- Qué servicios requieren automatización, soporte adicional o contratación.
+- Qué precio o paquete parece viable según evidencia.
 
 ---
 

--- a/docs/prueba-fogueo-mercado.md
+++ b/docs/prueba-fogueo-mercado.md
@@ -30,6 +30,8 @@ Estamos preguntando:
 
 ## Objetivo
 
+Medir recepción real del mercado antes de construir el producto completo.
+
 Medir la recepción real de pequeños negocios frente a una propuesta de:
 
 ```text
@@ -43,6 +45,19 @@ alertas de numeración/certificado
 +
 acompañamiento por WhatsApp
 ```
+
+---
+
+## Canales iniciales
+
+- Meta Ads.
+- Facebook Ads.
+- Landing page.
+- WhatsApp.
+- Publicaciones orgánicas.
+- Contacto con contadores.
+- Contacto con negocios pequeños.
+- Contacto con integradores/POS.
 
 ---
 
@@ -114,6 +129,18 @@ Preguntas:
 - ¿El contador maneja la facturación o solo la revisa?
 - ¿El contador recomendaría o bloquearía un cambio?
 - ¿Le gustaría que el sistema también ayude al contador?
+
+---
+
+## Hipótesis a validar
+
+- Existe interés real.
+- El cliente entiende la propuesta.
+- El cliente pagaría.
+- El soporte requerido no supera la capacidad de una sola persona.
+- Los servicios DIAN iniciales pueden mantenerse con bajo riesgo.
+- El mensaje comercial genera leads.
+- El precio hipotético no espanta al mercado.
 
 ---
 
@@ -231,6 +258,21 @@ Si nadie entiende “API”:
 - No aceptar personalizaciones complejas.
 - No construir más software antes de escuchar señales reales.
 - No interpretar “me parece interesante” como intención de pago.
+
+---
+
+## Métricas
+
+- Costo por lead.
+- Cantidad de leads.
+- Calidad de leads.
+- Preguntas frecuentes.
+- Objeciones.
+- Precio aceptado.
+- Tipo de cliente interesado.
+- Urgencia del problema.
+- Nivel de soporte solicitado.
+- Confianza/desconfianza frente a una solución nueva.
 
 ---
 

--- a/docs/session-context.md
+++ b/docs/session-context.md
@@ -2,6 +2,23 @@
 
 Copia o resume esto al **inicio** de una sesión si el chat está largo o cambias de máquina. Mantenlo corto; el análisis profundo va a Perplexity u otro agente largo.
 
+## Enfoque F0 corregido
+
+Antes de pedir código, confirmar que el trabajo actual sigue este orden:
+
+```text
+documentación → modelo → hipótesis → prueba de mercado → diagnóstico → decisión de MVP
+```
+
+Pregunta central:
+
+```text
+¿Puede una sola persona construir, vender, operar y mantener una API DIAN rentable,
+con servicios limitados, en el mercado actual?
+```
+
+No avanzar a XML, firma, envío DIAN ni lógica fiscal real sin evidencia mínima del mercado.
+
 ## Estado actual (rellenar)
 
 - **Rama:** `dev` / `feature/...`

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -2,6 +2,32 @@
 
 Flujo estándar para cualquier issue del proyecto API-DIAN, desde la idea hasta el cierre en `dev`, con evidencia y trazabilidad.
 
+## Corrección estratégica F0
+
+Durante F0, el workflow no debe llevar directamente de issue a construcción técnica DIAN.
+
+El flujo correcto es:
+
+```text
+documentación completa
+↓
+idea consolidada
+↓
+hipótesis claras
+↓
+construcción mínima solo para probar
+↓
+prueba de fogueo de mercado
+↓
+diagnóstico de viabilidad
+↓
+decisión sobre qué construir realmente
+```
+
+Codex/Cursor puede ejecutar cambios, pero no debe convertir una idea no validada en módulos fiscales reales.
+
+---
+
 ## Introducción
 
 **Propósito:** Ordenar el trabajo en issues, ramas, migraciones, PRs y cierre sin perder contexto ni duplicar decisiones.


### PR DESCRIPTION
﻿## Qué cambia

- Corrige el enfoque estratégico del proyecto.
- Aclara que la construcción inicial no es el producto final.
- Reordena el flujo: documentación → prueba de mercado → diagnóstico → decisión de MVP.
- Agrega la pregunta central de viabilidad para una sola persona.
- Actualiza documentación relacionada.
- Actualiza Obsidian directamente como memoria operativa del proyecto.

## Por qué cambia

Se detectó que el proyecto podía interpretarse como si el siguiente paso después de preparar el entorno fuera construir módulos DIAN.

La intención real es primero consolidar el modelo, probar recepción de mercado y diagnosticar si puede mantenerse por una sola persona.

## Issue relacionado

Relates to #42  
Relates to #43  
Relates to #44  
Relates to #45

## Fuera de alcance

- No implementa XML.
- No implementa firma.
- No implementa envío DIAN.
- No implementa lógica fiscal.
- No define todavía MVP técnico final.
- No modifica producción.

## Pruebas realizadas

- [x] Revisión documental.
- [x] Validación de enlaces internos.
- [x] Verificación de que no se agregó lógica DIAN.
- [x] No aplica build/test porque es cambio documental.

## Evidencia

Ver:

```text
docs/f0-correccion-enfoque-evidencia.md
```

Comentarios agregados:

- #42 — actualización de objetivo del modelo experimental.
- #43 — actualización de prueba de fogueo de mercado.
- #44 — actualización del rol del entorno diario.
- #45 — actualización del objetivo de prueba sin usuarios.

## Checklist de revisión humana

- [x] El enfoque corregido queda claro.
- [x] No se empuja construcción técnica prematura.
- [x] La pregunta de viabilidad unipersonal queda explícita.
- [x] La prueba de mercado queda como paso previo al MVP real.
- [x] Los issues principales quedan alineados.
- [x] Obsidian queda actualizado o con parche listo.
