### PR TITLE
[F0-MODEL] Consolidar modelo experimental y viabilidad unipersonal

### DIFF
--- a/docs/f0-modelo-experimental-evidencia.md
+++ b/docs/f0-modelo-experimental-evidencia.md
@@ -1,0 +1,68 @@
+# Evidencia — Consolidación modelo experimental #42
+
+## Fecha
+
+2026-06-29
+
+## Issue
+
+#42 — Consolidar definición del modelo experimental API-Dian.
+
+## Objetivo
+
+Consolidar `docs/modelo-experimental.md` como documento estable de decisión para responder si API-Dian puede ser viable, rentable y mantenible por una sola persona con servicios DIAN limitados.
+
+## Decisión aplicada
+
+El nombre **modelo experimental** se mantiene.
+
+El modelo queda definido como una etapa de producto, mercado y operación, no como construcción técnica DIAN.
+
+## Pregunta central aceptada
+
+```text
+¿Puede una sola persona construir, vender, operar y mantener una API DIAN rentable,
+con servicios limitados, en el mercado actual?
+```
+
+## Cambios realizados
+
+Se actualizó `docs/modelo-experimental.md` para incluir:
+
+- Estado de decisión.
+- Pregunta central y pregunta secundaria.
+- Definición consolidada del modelo.
+- Visión larga vs alcance inmediato.
+- Hipótesis principales.
+- Cliente objetivo inicial.
+- Clasificación inicial de servicios DIAN.
+- Paquetes hipotéticos.
+- Riesgos técnicos, operativos, comerciales y personales.
+- Condiciones de viabilidad para una sola persona.
+- Métricas de decisión.
+- Criterios para decidir viable / viable con cambios / no viable.
+- Criterio de cierre de #42.
+- Pendientes derivados hacia #43.
+
+## Fuera de alcance confirmado
+
+- No se implementó XML.
+- No se implementó firma digital.
+- No se implementó envío DIAN.
+- No se modificó arquitectura de código.
+- No se creó producto comercial.
+- No se prometió cobertura DIAN completa.
+
+## Estado final esperado
+
+- [x] `docs/modelo-experimental.md` revisado y ampliado.
+- [x] Nombre “modelo experimental” mantenido.
+- [x] Viabilidad unipersonal queda como pregunta central.
+- [x] Hipótesis, clientes, paquetes, riesgos y criterios quedan documentados.
+- [x] Siguiente paso definido: #43 — prueba de fogueo de mercado.
+- [ ] Comentario final en issue #42 después de revisión humana.
+- [ ] Obsidian actualizado o parche preparado si aplica.
+
+## Próximo paso
+
+Avanzar a #43: diseñar prueba de fogueo de mercado con Meta Ads, Facebook Ads, landing page, WhatsApp, segmentos, mensajes, objeciones y métricas.

--- a/docs/modelo-experimental.md
+++ b/docs/modelo-experimental.md
@@ -1,14 +1,23 @@
 # Modelo experimental API-Dian
 
-## Estado actual
+## Estado de decisión
 
-API-Dian se encuentra en fase de **modelo experimental**.
+**Estado:** definición consolidada para avanzar a diseño de prueba de mercado.
 
-El objetivo inmediato no es construir todavía toda la plataforma fiscal completa, sino validar el modelo de trabajo, la arquitectura inicial, los agentes, el manejo de errores, los paquetes, la operación mínima y la forma en que el mercado recibe la propuesta.
+**Issue relacionado:** #42.
 
-Este repositorio funciona como laboratorio controlado para convertir ideas en documentación, tickets, pruebas, código y evidencia.
+**Fecha:** 2026-06-29.
 
-La construcción inicial no es el producto final. La construcción inicial es una herramienta para probar recepción real del mercado y diagnosticar viabilidad.
+API-Dian se encuentra en **F0 — Consolidación documental del modelo experimental**.
+
+La decisión central de esta fase es:
+
+```text
+No construir el MVP real todavía.
+Primero consolidar el modelo, diseñar la prueba de mercado y diagnosticar viabilidad.
+```
+
+La construcción inicial no es el producto final. La construcción inicial solo debe existir si ayuda a probar recepción real del mercado.
 
 ---
 
@@ -22,17 +31,93 @@ con servicios limitados, en el mercado actual?
 Pregunta secundaria:
 
 ```text
-¿Qué habría que cambiar en el modelo para que eso sí sea posible?
+¿Qué habría que cambiar en el modelo para que esa meta sea posible?
 ```
 
-El modelo debe responder:
+El modelo debe responder con evidencia:
 
-- ¿Es viable construir y mantener esto con una sola persona?
-- ¿Qué servicios DIAN sí son manejables por una sola persona?
-- ¿Qué servicios deben descartarse al inicio?
-- ¿Qué partes requieren automatización?
-- ¿Qué partes exigirían contratar personal?
-- ¿Qué precio/paquete parece viable?
+- Si es viable construir y mantener esto con una sola persona.
+- Qué servicios DIAN sí son manejables por una sola persona.
+- Qué servicios deben descartarse al inicio.
+- Qué partes requieren automatización.
+- Qué partes exigirían contratar personal.
+- Qué precio o paquete parece viable.
+- Qué objeciones reales tiene el mercado.
+- Qué nivel de soporte exige el cliente.
+
+---
+
+## Definición consolidada
+
+API-Dian, en esta fase, es un **modelo experimental de producto y operación** para evaluar si vale la pena construir una API fiscal limitada alrededor de servicios DIAN.
+
+No se define todavía como:
+
+- Producto SaaS completo.
+- API pública madura.
+- Proveedor tecnológico completo.
+- Plataforma fiscal de cobertura total.
+- Sistema listo para clientes reales.
+
+Sí se define como:
+
+- Laboratorio de modelo de negocio.
+- Sistema de documentación y aprendizaje.
+- Prueba ordenada de hipótesis.
+- Base para medir recepción de mercado.
+- Marco para decidir qué construir y qué descartar.
+- Proyecto diseñado para evaluar operación de una sola persona.
+
+---
+
+## Visión larga
+
+La visión larga podría ser una plataforma intermediaria entre ERPs, POS, integradores, contadores o negocios y servicios fiscales DIAN.
+
+En visión larga podría incluir:
+
+- Factura electrónica.
+- Notas crédito y débito.
+- Documento soporte.
+- Eventos y respuestas.
+- Retorno al ERP.
+- Webhooks.
+- Notificación al adquiriente.
+- Panel operativo.
+- Multiempresa.
+- Automatización de soporte.
+
+Pero esta visión larga **no es el alcance actual**.
+
+---
+
+## Alcance inmediato
+
+El alcance inmediato de F0 y F0.5 es:
+
+```text
+consolidar modelo
+↓
+definir hipótesis
+↓
+diseñar prueba de mercado
+↓
+medir recepción
+↓
+diagnosticar viabilidad unipersonal
+```
+
+En esta etapa se permite trabajar en:
+
+- Documentación del modelo.
+- Hipótesis de cliente.
+- Hipótesis de precio.
+- Hipótesis de paquetes.
+- Riesgos de mantenimiento.
+- Plan de prueba con Meta Ads / Facebook Ads / landing / WhatsApp.
+- Criterios para decidir si se construye o no.
+
+No se permite pasar directamente a construcción fiscal DIAN real.
 
 ---
 
@@ -41,88 +126,301 @@ El modelo debe responder:
 En este contexto, **modelo** significa:
 
 ```text
-versión experimental del enfoque API-Dian
+propuesta de producto
 +
-sistema de trabajo con agentes
+cliente objetivo
 +
-forma de organizar ideas y tickets
+paquetes hipotéticos
 +
-prueba de paquetes y mercado
+servicios DIAN limitados
 +
-base técnica inicial para aprender con evidencia
+forma de operación para una sola persona
++
+canales de prueba de mercado
++
+sistema de trabajo con Obsidian, GitHub y Codex
++
+criterios de decisión
 ```
 
-No significa todavía:
+El modelo no es solo código.
 
-- SaaS final maduro.
-- API pública lista para terceros.
-- Proveedor tecnológico completo.
-- Cobertura total de servicios DIAN.
-- Producto comercial escalado.
+El modelo incluye:
+
+- Qué se ofrece.
+- A quién se ofrece.
+- Por qué pagaría.
+- Qué soporte exige.
+- Qué se puede mantener solo.
+- Qué debe automatizarse.
+- Qué debe descartarse.
+- Cuándo contratar.
+- Cuándo parar.
 
 ---
 
-## Qué se está probando
+## Hipótesis principales
 
-El modelo busca probar:
+Estas hipótesis deben validarse antes de construir el MVP real:
 
-- Cómo se consolidan ideas complejas.
-- Cómo se convierten ideas en tickets accionables.
-- Cómo se usa Obsidian como memoria estratégica.
-- Cómo se usa GitHub Project como tablero operativo.
-- Cómo se usa Codex como ejecutor por tickets.
-- Cómo se usa ChatGPT como arquitecto/revisor senior.
-- Cómo se diseñan agentes auditables.
-- Cómo se documenta evidencia.
-- Cómo se manejan errores DIAN.
-- Cómo se empaquetan servicios para una operación de una sola persona.
-- Cómo reacciona el mercado ante la propuesta.
-- Qué servicios DIAN puede mantener una sola persona sin saturarse.
-- Qué servicios requieren automatización, soporte adicional o contratación.
-- Qué precio o paquete parece viable según evidencia.
+1. Hay clientes que entienden el dolor de integración DIAN.
+2. Hay clientes dispuestos a pagar por una API o solución intermedia limitada.
+3. El cliente objetivo puede adquirir sin exigir soporte 24/7.
+4. Un paquete limitado puede ser operado por una sola persona.
+5. La carga de soporte no destruye la rentabilidad.
+6. El canal Meta Ads / Facebook Ads puede generar leads útiles o al menos señales de interés.
+7. WhatsApp puede servir como canal inicial de diagnóstico y preventa.
+8. El cliente no exige desde el inicio cobertura total DIAN.
+9. Los servicios iniciales pueden mantenerse con bajo riesgo normativo y operativo.
+10. La propuesta se puede explicar sin sonar como promesa de proveedor tecnológico completo.
 
 ---
 
-## Fase actual
+## Cliente objetivo inicial
 
-```text
-F0 — Consolidación del Modelo
-```
+El modelo debe comparar al menos estos perfiles:
 
-La fase actual se basa en ciclos de:
+### 1. Integradores / desarrolladores / software pequeño
 
-```text
-consulta
-↓
-corrección de errores
-↓
-consulta
-↓
-corrección de errores
-↓
-consolidación
-```
+Posible dolor:
 
-El objetivo es llegar a una base suficientemente clara antes de pasar de la teoría a pruebas reales.
+- Quieren integrar DIAN sin construir todo desde cero.
+- Buscan documentación simple.
+- Quieren endpoints claros.
+- Pueden tolerar una solución técnica.
+
+Riesgo:
+
+- Exigen confiabilidad técnica.
+- Pueden pedir más cobertura de la que una persona puede mantener.
+
+### 2. Contadores
+
+Posible dolor:
+
+- Manejan clientes que necesitan emitir o corregir documentos.
+- Pueden recomendar soluciones.
+- Entienden parte del problema fiscal.
+
+Riesgo:
+
+- Pueden requerir soporte humano alto.
+- Pueden preferir soluciones ya conocidas.
+
+### 3. Negocios pequeños con POS o ERP básico
+
+Posible dolor:
+
+- Necesitan facturación y soporte práctico.
+- Quieren algo fácil, no técnico.
+
+Riesgo:
+
+- Pueden saturar soporte.
+- Pueden no entender una “API”.
+- Pueden pedir interfaz, capacitación y atención constante.
+
+### 4. Proveedores de software local
+
+Posible dolor:
+
+- Quieren agregar facturación electrónica sin volverse expertos DIAN.
+
+Riesgo:
+
+- Requieren estabilidad, documentación y soporte técnico.
+- Pueden convertirse en clientes valiosos, pero exigentes.
 
 ---
 
-## Siguiente fase
+## Servicios DIAN: clasificación inicial
 
-```text
-F0.5 — Prueba de Fogueo
-```
+Esta clasificación es preliminar. Debe validarse con investigación técnica, normativa y mercado antes de construir.
 
-La prueba de fogueo no busca demostrar simplemente que “la idea es buena”. Busca observar cómo el mercado entiende y recibe la propuesta:
+### Posiblemente manejables por una persona al inicio
 
-- Qué entiende el cliente.
-- Qué le importa.
-- Qué objeciones presenta.
-- Qué tanto pesa el precio.
-- Qué tanto pesa el soporte.
-- Qué software conoce.
-- Qué papel tiene el contador.
-- Qué parte del mensaje despierta interés.
+- Validación y normalización de datos de factura.
+- Simulación de flujo de emisión sin envío real.
+- Diagnóstico de errores comunes de entrada.
+- Generación interna de estructura de documento.
+- Consulta/documentación de estados en modo experimental.
+- Pruebas sandbox limitadas cuando el modelo lo justifique.
+
+### Candidatos para MVP validado, no para F0
+
+- Factura electrónica básica.
+- Notas crédito/débito básicas.
+- Documento soporte básico.
+- Webhook de respuesta.
+- Notificación simple al adquiriente.
+
+### Deben descartarse al inicio
+
+- RADIAN.
+- Nómina electrónica completa.
+- Factoring.
+- Multiempresa compleja.
+- SLA 24/7.
+- Contabilidad completa.
+- Panel administrativo avanzado.
+- Soporte masivo a usuarios finales.
+- Automatizaciones críticas sin revisión humana.
+
+---
+
+## Paquetes hipotéticos
+
+Estos paquetes no son oferta final. Son hipótesis para probar lenguaje, precio, interés y soporte requerido.
+
+### Paquete A — Diagnóstico / Sandbox
+
+Para validar si el cliente entiende la propuesta.
+
+Incluye hipotéticamente:
+
+- Revisión de flujo actual.
+- Prueba de estructura de datos.
+- Diagnóstico de errores comunes.
+- Recomendación de integración.
+
+No incluye emisión real.
+
+### Paquete B — API limitada para integrador
+
+Para desarrolladores o software pequeño.
+
+Incluye hipotéticamente:
+
+- Endpoint de validación.
+- Estructura normalizada.
+- Errores claros.
+- Documentación simple.
+- Ambiente de prueba.
+
+No incluye soporte fiscal completo.
+
+### Paquete C — MVP fiscal básico validado
+
+Solo se consideraría después de prueba de mercado.
+
+Incluye hipotéticamente:
+
+- Servicio DIAN limitado.
+- Flujo controlado.
+- Logs.
+- Evidencia.
+- Manejo de errores.
+- Soporte acotado.
+
+No incluye cobertura DIAN total.
+
+---
+
+## Riesgos principales para una sola persona
+
+### Riesgo técnico
+
+- Cambios DIAN.
+- XML / firma / certificados.
+- Ambientes de prueba inestables.
+- Errores difíciles de reproducir.
+- Dependencia de servicios externos.
+
+### Riesgo operativo
+
+- Soporte por WhatsApp desbordado.
+- Clientes sin datos claros.
+- Casos urgentes en horarios no sostenibles.
+- Expectativa de soporte 24/7.
+- Falta de documentación interna.
+
+### Riesgo comercial
+
+- Mercado no entiende “API DIAN”.
+- Cliente quiere software completo, no API.
+- Precio aceptado menor al costo real de soporte.
+- Competidores con más confianza o trayectoria.
+- Ciclo de venta más largo de lo esperado.
+
+### Riesgo personal
+
+- Una sola persona puede convertirse en cuello de botella.
+- El soporte puede impedir construir.
+- El mantenimiento puede impedir vender.
+- La operación puede impedir estudiar y mejorar.
+
+---
+
+## Condiciones para que sea viable con una sola persona
+
+El modelo solo será viable si se cumplen varias condiciones:
+
+- Alcance muy limitado.
+- Servicios DIAN priorizados por bajo mantenimiento.
+- Soporte acotado por horario y canal.
+- Documentación fuerte.
+- Errores trazables.
+- Pruebas automáticas mínimas.
+- Onboarding simple.
+- Precios que cubran soporte y mantenimiento.
+- Automatización progresiva.
+- Cliente objetivo suficientemente técnico o bien filtrado.
+
+Si el cliente exige soporte intensivo, personalización alta o cobertura fiscal amplia, el modelo deja de ser viable para una sola persona.
+
+---
+
+## Métricas de decisión
+
+La prueba de mercado debe producir datos sobre:
+
+- Leads generados.
+- Costo por lead.
+- Calidad del lead.
+- Tipo de cliente interesado.
+- Preguntas frecuentes.
+- Objeciones.
+- Precio aceptado.
+- Nivel de urgencia.
+- Nivel de soporte requerido.
+- Confianza/desconfianza frente a solución nueva.
+- Servicios que el mercado pide primero.
+- Servicios que conviene descartar.
+
+---
+
+## Criterios para decidir
+
+### Viable
+
+El modelo puede considerarse viable si:
+
+- Hay leads reales.
+- El cliente entiende la propuesta.
+- El soporte requerido parece controlable.
+- El precio aceptado permite margen.
+- El alcance inicial puede mantenerse por una sola persona.
+- Los servicios solicitados no exigen cobertura total DIAN.
+
+### Viable con cambios
+
+El modelo puede ser viable con cambios si:
+
+- Hay interés, pero el mensaje no se entiende.
+- Hay interés, pero el cliente objetivo debe cambiar.
+- Hay interés, pero el paquete debe simplificarse.
+- Hay interés, pero el soporte debe automatizarse.
+- Hay interés, pero el precio debe ajustarse.
+
+### No viable para una persona
+
+El modelo no es viable para una sola persona si:
+
+- El soporte requerido es alto.
+- El cliente exige atención inmediata constante.
+- El mercado pide cobertura amplia desde el inicio.
+- El precio aceptado no cubre mantenimiento.
+- La confianza requerida exige equipo, certificaciones o trayectoria fuerte.
 
 ---
 
@@ -233,51 +531,39 @@ Obsidian actualiza aprendizaje
 
 ---
 
-## Reglas principales
+## Criterio de cierre de #42
 
-```text
-ChatGPT ordena.
-Obsidian conserva.
-GitHub ejecuta.
-Codex implementa.
-GitHub Project controla el día a día.
-```
+#42 puede cerrarse cuando:
 
-```text
-Nada importante queda solo en chat.
-Toda idea útil termina en Obsidian.
-Toda tarea accionable termina en GitHub Issue.
-Todo cambio técnico termina en PR.
-```
+- Este documento quede revisado.
+- Se confirme que “modelo experimental” se mantiene como nombre de fase.
+- Se confirme que el objetivo central es viabilidad para una sola persona.
+- Se documenten hipótesis, clientes, paquetes, riesgos y criterios de decisión.
+- Se confirme que el siguiente paso es #43.
+- Se deje comentario de decisión final en el issue #42.
+- Obsidian quede actualizado o se prepare parche.
 
 ---
 
-## Restricciones de alcance
+## Pendientes derivados
 
-Durante esta fase no se debe construir ni prometer:
+Después de #42, los siguientes trabajos son:
 
-- API pública madura para terceros.
-- RADIAN.
-- Nómina electrónica completa.
-- Factoring.
-- Multi-sede complejo.
-- Contabilidad completa.
-- SLA alto 24/7.
-- Automatizaciones críticas sin revisión humana.
+1. #43 — Diseñar prueba de fogueo de mercado.
+2. Definir mensajes comerciales para Meta Ads / Facebook Ads.
+3. Definir segmentos de cliente.
+4. Definir landing o formulario mínimo.
+5. Definir matriz de métricas.
+6. Definir guion de entrevista / WhatsApp.
+7. Definir criterios para pasar a prototipo mínimo.
 
 ---
 
-## Criterio de avance
+## Regla principal
 
-El modelo puede pasar a prueba de fogueo cuando exista:
-
-- Mapa Obsidian consolidado.
-- Backlog inicial convertido en issues.
-- GitHub Project operativo.
-- Documento de prueba de fogueo.
-- Guion de entrevista o diagnóstico.
-- Criterios de evaluación del mercado.
-- Primer flujo de prueba sin usuarios.
+```text
+No se construye el MVP real hasta tener evidencia mínima del mercado.
+```
 
 ---
 


### PR DESCRIPTION
## Qué cambia

- Consolida `docs/modelo-experimental.md` como documento de decisión para #42.
- Mantiene el nombre **modelo experimental**.
- Define la pregunta central de viabilidad para una sola persona.
- Separa visión larga vs alcance inmediato.
- Agrega hipótesis principales, cliente objetivo, paquetes hipotéticos, riesgos y criterios de decisión.
- Crea `docs/f0-modelo-experimental-evidencia.md`.

## Por qué cambia

Después de cerrar el entorno mínimo y corregir el enfoque estratégico, #42 debe dejar estable el modelo antes de pasar a #43.

La decisión clave es que API-Dian no pasa todavía a construcción DIAN real. Primero debe diagnosticar si una sola persona puede construir, vender, operar y mantener un modelo limitado y rentable.

## Issue relacionado

Relates to #42

## Fuera de alcance

- No implementa XML.
- No implementa firma digital.
- No implementa envío DIAN.
- No modifica arquitectura de código.
- No define MVP técnico final.
- No crea producto comercial.

## Pruebas realizadas

- [x] Revisión documental.
- [x] Verificación de que no se agregó lógica DIAN.
- [x] No aplica build/test porque solo modifica documentación.

## Evidencia

Ver:

```text
docs/f0-modelo-experimental-evidencia.md
```

## Checklist de revisión humana

- [ ] El modelo experimental queda suficientemente definido.
- [ ] La pregunta de viabilidad unipersonal queda explícita.
- [ ] La visión larga no se confunde con alcance inmediato.
- [ ] Los riesgos para una sola persona quedan claros.
- [ ] Los paquetes son hipótesis, no promesas comerciales.
- [ ] El siguiente paso queda como #43, no construcción DIAN.
